### PR TITLE
Fix property name

### DIFF
--- a/src/main/java/pro/samcik/raydium/timer/Scheduler.java
+++ b/src/main/java/pro/samcik/raydium/timer/Scheduler.java
@@ -40,7 +40,7 @@ public class Scheduler {
         }
     }
 
-    @Scheduled(fixedRateString = "${config.record-pool-status-rate}")
+    @Scheduled(fixedRateString = "${config.record-pool-details-rate}")
     public void recordPoolDetails() {
         log.info("Recording pool details {}", formatter.format(LocalDateTime.now()));
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
 config:
   check-range-rate: 300000
   check-pool-status-rate: 3600000
-  record-pool-status-rate: 3600000
+  record-pool-details-rate: 3600000
   position:
     id: FGwfdpXfhoSLda7wb7rsPfY9HLBKQmaDCvmeQHggAqpF
     range:


### PR DESCRIPTION
## Summary
- rename `record-pool-status-rate` property to `record-pool-details-rate`
- update the scheduled annotation to use the new property key

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684ded5cc9dc832897736ac1ffac4e34