### PR TITLE
Add configuration annotation for ObjectMapper

### DIFF
--- a/src/main/java/pro/samcik/raydium/config/ObjectMapperConfiguration.java
+++ b/src/main/java/pro/samcik/raydium/config/ObjectMapperConfiguration.java
@@ -3,7 +3,9 @@ package pro.samcik.raydium.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
+@Configuration
 public class ObjectMapperConfiguration {
 
     @Bean


### PR DESCRIPTION
## Summary
- enable `ObjectMapperConfiguration` as a configuration class

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684ded643e9c8328b9d46ebeb8413f53