### PR TITLE
Remove service annotation from interface

### DIFF
--- a/src/main/java/pro/samcik/raydium/service/RangeChecker.java
+++ b/src/main/java/pro/samcik/raydium/service/RangeChecker.java
@@ -1,9 +1,7 @@
 package pro.samcik.raydium.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.springframework.stereotype.Service;
 
-@Service
 public interface RangeChecker {
 
     void checkRange() throws JsonProcessingException;


### PR DESCRIPTION
## Summary
- clean up `RangeChecker` so that interfaces do not have Spring annotations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - repo.maven.apache.org unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ded696b208328abc4600602c1bb62